### PR TITLE
Backspace clears the whole line

### DIFF
--- a/argparse_prompt.py
+++ b/argparse_prompt.py
@@ -63,9 +63,10 @@ class Prompt:
         try:
             # If the user provided no value for this argument, prompt them for it
             if val == '':
-                print('{}{}\n> {}'.format(self.name, help_str, default_str), end='', file=sys.stderr)
+                prompt = '{}{}\n> {}'.format(self.name, help_str, default_str)
 
-                newval = getpass.getpass(prompt='') if self.secure else input()
+                newval = getpass.getpass(prompt=prompt) \
+                    if self.secure else input(prompt)
 
                 # If they just hit enter, they want the default value
                 if newval == '':


### PR DESCRIPTION
The following is due to issue https://bugs.python.org/issue12833

Steps:
1. Add a prompt argument
2. When prompted, write a char and then backspace

Before this PR:
The whole line is cleared

After this PR:
Only the written char is cleared